### PR TITLE
Add installer build workflow

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,37 @@
+name: Build Installer
+on:
+  workflow_dispatch:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build deps
+        run: |
+          pip install uv
+          uv pip install -r requirements.txt
+          uv pip install pyinstaller cyclonedx-py cosign
+      - name: Build binary
+        run: |
+          pyinstaller --onefile --name ytm-neoplayer ytm_player/__main__.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ytm-neoplayer-${{ matrix.os }}
+          path: dist/ytm-neoplayer*
+      - name: Generate SBOM & Sign artefacts
+        run: |
+          cyclonedx-py -o sbom.xml
+          cosign attest --yes --output-signature sbom.sig sbom.xml

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ ruff check .
 ruff format --check .
 pytest -q
 ```
+
+## Installer Builds
+
+Tagged releases trigger a GitHub Actions workflow that bundles the application with PyInstaller. Pre-built binaries for Windows, macOS and Linux can be downloaded from the workflow run artifacts.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build PyInstaller installers on tag push
- document installer builds in README

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421487323c8329877d9e6e8c95ae0a