### PR TITLE
Fix pyinstaller entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.7 - 2025-06-09
+
+- Fix PyInstaller entrypoint to allow running packaged binary.
+
 ## 1.0.6 - 2025-06-08
 
 - Use `cosign sign-blob` to sign SBOM and update docs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ytm-neoplayer"
-version = "1.0.6"
+version = "1.0.7"
 description = "Minimal YouTube Music desktop player"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ytm_player/__main__.py
+++ b/ytm_player/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from PySide6.QtWidgets import QApplication  # type: ignore
 
-from .ui.main_window import MainWindow
+from ytm_player.ui.main_window import MainWindow
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix PyInstaller entrypoint by using absolute import
- bump version to 1.0.7
- document change in changelog

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68444272aa608329b0487613daa950a2