### PR TITLE
Fix NSIS installer path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.10 - 2025-06-07
+
+- Fix Windows NSIS installer path to the built executable.
+
 ## 1.0.9 - 2025-06-07
 
 - Add GUI installers for macOS (DMG) and Linux (makeself).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ytm-neoplayer"
-version = "1.0.9"
+version = "1.0.10"
 description = "Minimal YouTube Music desktop player"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -5,6 +5,7 @@ Page directory
 Page instfiles
 Section "Main" SecMain
   SetOutPath $INSTDIR
-  File "dist\\ytm-neoplayer.exe"
+  ; Path is relative to this script's directory, so step out one level
+  File "..\\dist\\ytm-neoplayer.exe"
   CreateShortCut "$DESKTOP\\YT Music Player.lnk" "$INSTDIR\\ytm-neoplayer.exe"
 SectionEnd


### PR DESCRIPTION
## Summary
- point NSIS script to correct path
- bump version to 1.0.10
- document fix in `CHANGELOG`

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68445cecfac883298ddf8f26a22c4fe9